### PR TITLE
Shorten fpsheaven radar aliases to fix console length error

### DIFF
--- a/custom/fpsheaven_radar.cfg
+++ b/custom/fpsheaven_radar.cfg
@@ -1,22 +1,34 @@
 // https://fpsheaven.com/cs2-radar-presets/
 
+// ---------- SHARED BASE ----------
+alias "rset" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background 1; cl_radar_always_centered 0; cl_radar_rotate 1; cl_radar_show_all_players_when_spectating 1; cl_radar_square_always 0; cl_radar_square_when_spectating 1; cl_teammate_colors_show 1"
+
+// ---------- DEFAULT ZOOM HELPERS ----------
+alias "rdz_anc"  "cl_radar_scale 0.34"
+alias "rdz_d2"   "cl_radar_scale 0.33"
+alias "rdz_mir"  "cl_radar_scale 0.35"
+alias "rdz_inf"  "cl_radar_scale 0.32"
+alias "rdz_nuke" "cl_radar_scale 0.54"
+alias "rdz_anu"  "cl_radar_scale 0.4"
+alias "rdz_ovp"  "cl_radar_scale 0.36"
+
 // ---------- ANCIENT ----------
-alias "anc" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background true; cl_hud_radar_scale 1.15; cl_radar_always_centered false; cl_radar_icon_scale_min 0.4; cl_radar_rotate true; cl_radar_scale 0.34; alias "radardefaultzoom" "cl_radar_scale 0.34"; cl_radar_scale_dynamic false; cl_radar_show_all_players_when_spectating true; cl_radar_square_always false; cl_radar_square_when_spectating true; cl_radar_square_with_scoreboard true; cl_teammate_colors_show 1; echo [RADAR] Ancient loaded"
+alias "anc"  "rset; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.4; rdz_anc; alias radardefaultzoom rdz_anc; cl_radar_scale_dynamic 0; cl_radar_square_with_scoreboard 1; echo [RADAR] Ancient loaded"
 
 // ---------- DUST 2 ----------
-alias "d2" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background true; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.2; cl_radar_always_centered false; cl_radar_icon_scale_min 0.6; cl_radar_rotate true; cl_radar_scale 0.33; alias "radardefaultzoom" "cl_radar_scale 0.33"; cl_radar_scale_dynamic true; cl_radar_show_all_players_when_spectating true; cl_radar_square_always false; cl_radar_square_when_spectating true; cl_radar_square_with_scoreboard true; cl_teammate_colors_show 1; echo [RADAR] Dust 2 loaded"
+alias "d2"   "rset; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.2; cl_radar_icon_scale_min 0.6; rdz_d2; alias radardefaultzoom rdz_d2; cl_radar_scale_dynamic 1; cl_radar_square_with_scoreboard 1; echo [RADAR] Dust 2 loaded"
 
 // ---------- MIRAGE ----------
-alias "mir" "cl_radar_scale 0.35; alias "radardefaultzoom" "cl_radar_scale 0.35";  cl_radar_icon_scale_min 0.4; cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background 1; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.15; cl_radar_always_centered 0; cl_radar_rotate 1; cl_radar_scale_alternate 0.3; cl_radar_scale_dynamic 0; cl_radar_show_all_players_when_spectating 1; cl_radar_square_always 0; cl_radar_square_when_spectating 1; cl_teammate_colors_show 1; echo [RADAR] Mirage loaded"
+alias "mir"  "rset; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.4; rdz_mir; alias radardefaultzoom rdz_mir; cl_radar_scale_alternate 0.3; cl_radar_scale_dynamic 0; echo [RADAR] Mirage loaded"
 
 // ---------- INFERNO ----------
-alias "inf" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background true; cl_hud_radar_scale 1.15; cl_radar_always_centered false; cl_radar_icon_scale_min 0.4; cl_radar_rotate true; cl_radar_scale 0.32; alias "radardefaultzoom" "cl_radar_scale 0.32"; cl_radar_scale_dynamic false; cl_radar_show_all_players_when_spectating true; cl_radar_square_always false; cl_radar_square_when_spectating true; cl_radar_square_with_scoreboard true; cl_teammate_colors_show 1; echo [RADAR] Inferno loaded"
+alias "inf"  "rset; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.4; rdz_inf; alias radardefaultzoom rdz_inf; cl_radar_scale_dynamic 0; cl_radar_square_with_scoreboard 1; echo [RADAR] Inferno loaded"
 
 // ---------- NUKE ----------
-alias "nuke" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background true; cl_hud_radar_scale 1.15; cl_radar_always_centered false; cl_radar_icon_scale_min 0.6; cl_radar_rotate true; cl_radar_scale 0.54; alias "radardefaultzoom" "cl_radar_scale 0.54"; cl_radar_scale_dynamic false; cl_radar_show_all_players_when_spectating true; cl_radar_square_always false; cl_radar_square_when_spectating true; cl_radar_square_with_scoreboard true; cl_teammate_colors_show 1; echo [RADAR] Nuke loaded"
+alias "nuke" "rset; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.6; rdz_nuke; alias radardefaultzoom rdz_nuke; cl_radar_scale_dynamic 0; cl_radar_square_with_scoreboard 1; echo [RADAR] Nuke loaded"
 
 // ---------- ANUBIS ----------
-alias "anu" "cl_radar_scale 0.4; alias "radardefaultzoom" "cl_radar_scale 0.4"; cl_radar_icon_scale_min 0.6; cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background 1; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.15; cl_radar_always_centered 0; cl_radar_rotate 1; cl_radar_scale_alternate 0.3; cl_radar_scale_dynamic 0; cl_radar_show_all_players_when_spectating 1; cl_radar_square_always 0; cl_radar_square_when_spectating 1; cl_teammate_colors_show 1; echo [RADAR] Anubis loaded"
+alias "anu"  "rset; cl_hud_radar_map_additive 1; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.6; rdz_anu; alias radardefaultzoom rdz_anu; cl_radar_scale_alternate 0.3; cl_radar_scale_dynamic 0; echo [RADAR] Anubis loaded"
 
 // ---------- OVERPASS ----------
-alias "ovp" "cl_drawhud_force_radar 0; cl_hud_radar_background_alpha 0.85; cl_hud_radar_blur_background true; cl_hud_radar_scale 1.15; cl_radar_always_centered false; cl_radar_icon_scale_min 0.4; cl_radar_rotate true; cl_radar_scale 0.36; alias "radardefaultzoom" "cl_radar_scale 0.36"; cl_radar_scale_dynamic false; cl_radar_show_all_players_when_spectating true; cl_radar_square_always false; cl_radar_square_when_spectating true; cl_radar_square_with_scoreboard true; cl_teammate_colors_show 1; echo [RADAR] Overpass loaded"
+alias "ovp"  "rset; cl_hud_radar_scale 1.15; cl_radar_icon_scale_min 0.4; rdz_ovp; alias radardefaultzoom rdz_ovp; cl_radar_scale_dynamic 0; cl_radar_square_with_scoreboard 1; echo [RADAR] Overpass loaded"


### PR DESCRIPTION
## Summary

- Extracted 9 shared cvars into a `rset` base alias to avoid repeating them in every map alias
- Added `rdz_*` helper aliases (e.g. `rdz_anc`, `rdz_d2`) to replace the inline nested `alias "radardefaultzoom" "..."` that was pushing strings over the console length limit
- Each map alias is now ~200 chars instead of 500+, well within CS2's console limit

## Test plan

- [ ] Run `exec custom/fpsheaven_radar` in console — should load without errors
- [ ] Run each map alias (`anc`, `d2`, `mir`, `inf`, `nuke`, `anu`, `ovp`) and verify radar settings apply correctly
- [ ] Run `radardefaultzoom` after loading a map alias and confirm it resets to the correct scale for that map

https://claude.ai/code/session_01M4zzD6imNqcv44rqoLoNJC